### PR TITLE
LanternCustomization

### DIFF
--- a/Ahorn/entities/lantern.jl
+++ b/Ahorn/entities/lantern.jl
@@ -2,7 +2,7 @@ module JungleHelperLantern
 
 using ..Ahorn, Maple
 
-@mapdef Entity "JungleHelper/Lantern" Lantern(x::Integer, y::Integer, sprite::String="", onlyIfMaddyNotHolding::Bool=false)
+@mapdef Entity "JungleHelper/Lantern" Lantern(x::Integer, y::Integer, sprite::String="", lightSprite::String="JungleHelper/Lantern/Overlay", onlyIfMaddyNotHolding::Bool=false)
 
 const placements = Ahorn.PlacementDict(
     "Lantern (Jungle Helper)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -192,6 +192,7 @@ placements.entities.JungleHelper/Cobweb.tooltips.sprite=If you want to reskin th
 # Lantern
 placements.entities.JungleHelper/Lantern.tooltips.sprite=If you want to reskin the lantern, define a custom sprite in your map's Sprites.xml and put the sprite name in this field. You can find the original sprite definition in Jungle Helper's zip, in Graphics/JungleHelper/CustomSprites.xml.
 placements.entities.JungleHelper/Lantern.tooltips.onlyIfMaddyNotHolding=If checked, the lantern will only spawn if Madeline isn't already holding a lantern when entering the room.
+placements.entities.JungleHelper/Lantern.tooltips.lightSprite=What sprite to use for the lantern's light, relative to the Gameplay folder.
 
 # Breakable Pot
 placements.entities.JungleHelper/BreakablePot.tooltips.sprite=If you want to reskin the breakable pot, define a custom sprite in your map's Sprites.xml and put the sprite name in this field. You can find the original sprite definition in Jungle Helper's zip, in Graphics/JungleHelper/CustomSprites.xml.

--- a/Code/Entities/Lantern.cs
+++ b/Code/Entities/Lantern.cs
@@ -58,6 +58,7 @@ namespace Celeste.Mod.JungleHelper.Entities {
         private ComponentWithDepth<Image> lanternOverlay;
 
         private readonly string reskinName;
+        private readonly string lightPath;
         private readonly bool onlyIfMaddyNotHolding;
 
         // registers the player's position when the lantern was dropped (if it was dropped),
@@ -72,6 +73,7 @@ namespace Celeste.Mod.JungleHelper.Entities {
             startingPosition = Position;
 
             reskinName = data.Attr("sprite");
+            lightPath = data.Attr("lightSprite", defaultValue: "JungleHelper/Lantern/Overlay");
             onlyIfMaddyNotHolding = data.Bool("onlyIfMaddyNotHolding", defaultValue: false);
 
             Add(new PlayerCollider(onPlayer));
@@ -83,7 +85,7 @@ namespace Celeste.Mod.JungleHelper.Entities {
                 };
             }
 
-            Image overlay = new Image(GFX.Game["JungleHelper/Lantern/Overlay"]);
+            Image overlay = new Image(GFX.Game[lightPath]);
             overlay.Position = new Vector2((int) (Center - Position).X, (int) (Center - Position).Y);
             overlay.CenterOrigin();
             Add(lanternOverlay = new ComponentWithDepth<Image>(overlay) { Depth = 1500 });
@@ -129,6 +131,7 @@ namespace Celeste.Mod.JungleHelper.Entities {
                 playerData["JungleHelper_LanternStartingPosition"] = startingPosition;
                 playerData["JungleHelper_LanternDoRespawn"] = doRespawn;
                 playerData["JungleHelper_LanternReskinName"] = reskinName;
+                playerData["JungleHelper_LanternLightPath"] = lightPath;
                 playerData["JungleHelper_LanternDropTimer"] = 0.25f;
 
                 // detach the glow from the lantern and attach it to the player.
@@ -301,9 +304,14 @@ namespace Celeste.Mod.JungleHelper.Entities {
                 reskinName = playerData.Get<string>("JungleHelper_LanternReskinName");
             }
 
+            string lightPath = "";
+            if (playerData.Data.ContainsKey("JungleHelper_LanternLightPath")) {
+                lightPath = playerData.Get<string>("JungleHelper_LanternLightPath");
+            }
+
             Lantern lantern = new Lantern(new EntityData {
                 Position = new Vector2((int) player.Center.X, (int) player.Center.Y - 5f),
-                Values = new System.Collections.Generic.Dictionary<string, object>() { { "sprite", reskinName } }
+                Values = new System.Collections.Generic.Dictionary<string, object>() { { "sprite", reskinName },{ "lightSprite", lightPath} }
             }, Vector2.Zero);
 
             lantern.regrabDelay = 0.25f;
@@ -350,7 +358,6 @@ namespace Celeste.Mod.JungleHelper.Entities {
 
             orig();
         }
-
 
         public static float GetClosestLanternDistanceTo(Vector2 position, Scene scene, out Vector2 objectPosition) {
             float distance = float.MaxValue;

--- a/Code/Entities/Lantern.cs
+++ b/Code/Entities/Lantern.cs
@@ -311,7 +311,7 @@ namespace Celeste.Mod.JungleHelper.Entities {
 
             Lantern lantern = new Lantern(new EntityData {
                 Position = new Vector2((int) player.Center.X, (int) player.Center.Y - 5f),
-                Values = new System.Collections.Generic.Dictionary<string, object>() { { "sprite", reskinName },{ "lightSprite", lightPath} }
+                Values = new System.Collections.Generic.Dictionary<string, object>() { { "sprite", reskinName }, { "lightSprite", lightPath } }
             }, Vector2.Zero);
 
             lantern.regrabDelay = 0.25f;

--- a/Loenn/entities/lantern.lua
+++ b/Loenn/entities/lantern.lua
@@ -8,13 +8,19 @@ lantern.placements = {
         name = "default",
         data = {
             sprite = "",
-            onlyIfMaddyNotHolding = false,
+            lightSprite = "JungleHelper/Lantern/Overlay",
+            onlyIfMaddyNotHolding = false
         }
     }
 }
 
 lantern.offset = { 10, 5 }
+lantern.justification = { 0, 0 }
 lantern.texture = "JungleHelper/Lantern/LanternEntity/lantern_00"
+
+lantern.fieldOrder = {
+    "x","y","sprite","lightSprite","onlyIfMaddyNotHolding"
+}
 
 function lantern.selection(room, entity)
     return utils.rectangle(entity.x - 5, entity.y - 2, 10, 10)

--- a/Loenn/entities/lantern.lua
+++ b/Loenn/entities/lantern.lua
@@ -17,10 +17,7 @@ lantern.placements = {
 lantern.offset = { 10, 5 }
 lantern.justification = { 0, 0 }
 lantern.texture = "JungleHelper/Lantern/LanternEntity/lantern_00"
-
-lantern.fieldOrder = {
-    "x","y","sprite","lightSprite","onlyIfMaddyNotHolding"
-}
+lantern.fieldOrder = { "x", "y", "sprite", "lightSprite", "onlyIfMaddyNotHolding" }
 
 function lantern.selection(room, entity)
     return utils.rectangle(entity.x - 5, entity.y - 2, 10, 10)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -146,7 +146,6 @@ entities.JungleHelper/Lantern.placements.name.default=Lantern
 entities.JungleHelper/Lantern.attributes.description.sprite=If you want to reskin the lantern, define a custom sprite in your map's Sprites.xml and put the sprite name in this field.\nYou can find the original sprite definition in Jungle Helper's zip, in Graphics/JungleHelper/CustomSprites.xml.
 entities.JungleHelper/Lantern.attributes.description.onlyIfMaddyNotHolding=If checked, the lantern will only spawn if Madeline isn't already holding a lantern when entering the room.
 entities.JungleHelper/Lantern.attributes.description.lightSprite=What sprite to use for the lantern's light, relative to the Gameplay folder.
-entities.JungleHelper/Lantern.attributes.description.spawnWithMaddy=If checked, Madeline will spawn while already holding this lantern.
 
 # Mossy Wall
 entities.JungleHelper/MossyWall.placements.name.left=Mossy Wall (Left)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -145,6 +145,8 @@ entities.JungleHelper/Hawk.attributes.description.sprite=If you want to reskin t
 entities.JungleHelper/Lantern.placements.name.default=Lantern
 entities.JungleHelper/Lantern.attributes.description.sprite=If you want to reskin the lantern, define a custom sprite in your map's Sprites.xml and put the sprite name in this field.\nYou can find the original sprite definition in Jungle Helper's zip, in Graphics/JungleHelper/CustomSprites.xml.
 entities.JungleHelper/Lantern.attributes.description.onlyIfMaddyNotHolding=If checked, the lantern will only spawn if Madeline isn't already holding a lantern when entering the room.
+entities.JungleHelper/Lantern.attributes.description.lightSprite=What sprite to use for the lantern's light, relative to the Gameplay folder.
+entities.JungleHelper/Lantern.attributes.description.spawnWithMaddy=If checked, Madeline will spawn while already holding this lantern.
 
 # Mossy Wall
 entities.JungleHelper/MossyWall.placements.name.left=Mossy Wall (Left)

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: JungleHelper
-  Version: 1.3.2
+  Version: 1.3.3
   DLL: Code/bin/Release/net452/JungleHelper.dll
   Dependencies:
     - Name: Everest


### PR DESCRIPTION
The light overlay created by lanterns can now be resprited using a new field. Lönn and Ahorn plugins were updated, including fixing the offset issue in lönn. The version in the everest.yaml has been changed to 1.3.3.