### PR TITLE
Fix Mossy Wall always using bottom texture instead of middle texture

### DIFF
--- a/Code/Entities/MossyWall.cs
+++ b/Code/Entities/MossyWall.cs
@@ -113,8 +113,9 @@ namespace Celeste.Mod.JungleHelper.Entities {
             List<Collider> hitboxes = new List<Collider>();
             List<bool> hitboxToggles = new List<bool>();
 
+            Calc.PushRandom();
             for (int i = 0; i < data.Height; i += 8) {
-                string id = (i == 0) ? "moss_top" : (i + 16 <= Height ? "moss_mid" + Calc.Random.Next(1, 3) : "moss_bottom");
+                string id = (i == 0) ? "moss_top" : (i + 16 <= data.Height ? "moss_mid" + Calc.Random.Next(1, 3) : "moss_bottom");
                 Image sprite = new Image(GFX.Game[data.Attr("spriteDirectory", "JungleHelper/Moss") + "/" + id]);
                 sprite.Position = new Vector2(0f, i);
                 sprite.FlipX = !left;
@@ -131,6 +132,7 @@ namespace Celeste.Mod.JungleHelper.Entities {
                 hitboxes.Add(hitbox);
                 hitboxToggles.Add(true);
             }
+            Calc.PopRandom();
 
             this.mossParts = mossParts.ToArray();
             this.hitboxes = hitboxes.ToArray();


### PR DESCRIPTION
fixes mossy walls mistakenly checking against `Height` (which will always be `0` since no collider is set yet) rather than `data.Height` when choosing which of its textures to use, which made it so the bottom texture always got picked instead of the middle texture

not sure if the `Calc.Random.Next` call actually being ran all of a sudden would've broken any maps so this also adds a `Calc.PushRandom` and `Calc.PopRandom` around the sprite generation code just to try and be safe